### PR TITLE
feat: option to close editor after publish (#33)

### DIFF
--- a/i18n/de.po
+++ b/i18n/de.po
@@ -405,6 +405,10 @@ msgctxt "feature_import-existing_setting_showDialogWhenEmpty_label"
 msgid "Show import dialog at start when page is empty"
 msgstr "Importdialog beim Start anzeigen, wenn die Seite leer ist"
 
+msgctxt "feature_publish_setting_closeAfterPublish_label"
+msgid "Close editor after publishing"
+msgstr "Nach «Veröffentlichen» den Editor schliessen"
+
 msgctxt "feature_settings_setting_lowPerformanceMode_label"
 msgid "Enable low performance mode"
 msgstr "Modus für niedrige Leistung aktivieren"
@@ -780,9 +784,21 @@ msgstr ""
 "Zeigt einen QR-Code an, um eine Vorschau der Änderungen mit Ihrem "
 "Smartphone zu öffnen."
 
+msgctxt "publishAndCloseLabel"
+msgid "Publish & Close"
+msgstr "Veröffentlichen & Schliessen"
+
+msgctxt "publishAndCloseLabelUnpublished"
+msgid "Save & Close"
+msgstr "Speichern & Schliessen"
+
 msgctxt "publishDescription"
-msgid "Make all changes public"
-msgstr "Alle Änderungen öffentlich machen"
+msgid "Publish all changes."
+msgstr "Alle Änderungen veröffentlichen"
+
+msgctxt "publishDescriptionUnpublished"
+msgid "Save all changes while keeping page unpublished"
+msgstr "Alle Änderungen speichern ohne die Seite zu publizieren"
 
 msgctxt "publishError"
 msgid "Changes could not be published."
@@ -791,6 +807,10 @@ msgstr "Änderungen konnten nicht publiziert werden."
 msgctxt "publishLabel"
 msgid "Publish"
 msgstr "Veröffentlichen"
+
+msgctxt "publishLabelUnpublished"
+msgid "Save"
+msgstr "Speichern"
 
 msgctxt "publishSuccess"
 msgid "Changes published successfully."
@@ -836,7 +856,7 @@ msgstr "Änderungen konnten nicht verworfen werden."
 
 msgctxt "revertMenuDescription"
 msgid "Restore currently published state"
-msgstr "Aktuell veröffentlichter Zustand Wiederherstellen"
+msgstr "Aktuell veröffentlichten Zustand wiederherstellen"
 
 msgctxt "revertMenuTitle"
 msgid "Discard..."

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -391,6 +391,10 @@ msgctxt "feature_import-existing_setting_showDialogWhenEmpty_label"
 msgid "Show import dialog at start when page is empty"
 msgstr ""
 
+msgctxt "feature_publish_setting_closeAfterPublish_label"
+msgid "Close editor after publishing"
+msgstr ""
+
 msgctxt "feature_settings_setting_lowPerformanceMode_label"
 msgid "Enable low performance mode"
 msgstr ""
@@ -753,9 +757,21 @@ msgid ""
 "smartphone."
 msgstr ""
 
+msgctxt "publishAndCloseLabel"
+msgid "Publish & Close"
+msgstr ""
+
+msgctxt "publishAndCloseLabelUnpublished"
+msgid "Save & Close"
+msgstr ""
+
 msgctxt "publishDescription"
-msgid "Make all changes public"
+msgid "Publish all changes."
 msgstr "Rendre toutes les modifications publiques"
+
+msgctxt "publishDescriptionUnpublished"
+msgid "Save all changes while keeping page unpublished"
+msgstr ""
 
 msgctxt "publishError"
 msgid "Changes could not be published."
@@ -764,6 +780,10 @@ msgstr "Les modifications n’ont pas pu être publiées."
 msgctxt "publishLabel"
 msgid "Publish"
 msgstr "Publier"
+
+msgctxt "publishLabelUnpublished"
+msgid "Save"
+msgstr ""
 
 msgctxt "publishSuccess"
 msgid "Changes published successfully."

--- a/i18n/gsw_CH.po
+++ b/i18n/gsw_CH.po
@@ -386,6 +386,10 @@ msgctxt "feature_import-existing_setting_showDialogWhenEmpty_label"
 msgid "Show import dialog at start when page is empty"
 msgstr "Importdialog bim Start aazeige wenn d'Sitte leer isch"
 
+msgctxt "feature_publish_setting_closeAfterPublish_label"
+msgid "Close editor after publishing"
+msgstr ""
+
 msgctxt "feature_settings_setting_lowPerformanceMode_label"
 msgid "Enable low performance mode"
 msgstr ""
@@ -751,9 +755,21 @@ msgid ""
 "smartphone."
 msgstr ""
 
+msgctxt "publishAndCloseLabel"
+msgid "Publish & Close"
+msgstr ""
+
+msgctxt "publishAndCloseLabelUnpublished"
+msgid "Save & Close"
+msgstr ""
+
 msgctxt "publishDescription"
-msgid "Make all changes public"
+msgid "Publish all changes."
 msgstr "Alli änderige öffentlich mache."
+
+msgctxt "publishDescriptionUnpublished"
+msgid "Save all changes while keeping page unpublished"
+msgstr ""
 
 msgctxt "publishError"
 msgid "Changes could not be published."
@@ -762,6 +778,10 @@ msgstr "D'Änderige hän nid chönne publiziert wärde."
 msgctxt "publishLabel"
 msgid "Publish"
 msgstr "Publiziere"
+
+msgctxt "publishLabelUnpublished"
+msgid "Save"
+msgstr ""
 
 msgctxt "publishSuccess"
 msgid "Changes published successfully."

--- a/i18n/it.po
+++ b/i18n/it.po
@@ -391,6 +391,10 @@ msgctxt "feature_import-existing_setting_showDialogWhenEmpty_label"
 msgid "Show import dialog at start when page is empty"
 msgstr ""
 
+msgctxt "feature_publish_setting_closeAfterPublish_label"
+msgid "Close editor after publishing"
+msgstr ""
+
 msgctxt "feature_settings_setting_lowPerformanceMode_label"
 msgid "Enable low performance mode"
 msgstr ""
@@ -753,9 +757,21 @@ msgid ""
 "smartphone."
 msgstr ""
 
+msgctxt "publishAndCloseLabel"
+msgid "Publish & Close"
+msgstr ""
+
+msgctxt "publishAndCloseLabelUnpublished"
+msgid "Save & Close"
+msgstr ""
+
 msgctxt "publishDescription"
-msgid "Make all changes public"
+msgid "Publish all changes."
 msgstr "Rendi pubbliche tutte le modifiche"
+
+msgctxt "publishDescriptionUnpublished"
+msgid "Save all changes while keeping page unpublished"
+msgstr ""
 
 msgctxt "publishError"
 msgid "Changes could not be published."
@@ -764,6 +780,10 @@ msgstr "Le modifiche non possono essere pubblicate."
 msgctxt "publishLabel"
 msgid "Publish"
 msgstr "Pubblica"
+
+msgctxt "publishLabelUnpublished"
+msgid "Save"
+msgstr ""
 
 msgctxt "publishSuccess"
 msgid "Changes published successfully."

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@blokkli/editor",
-      "version": "1.0.0",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@nuxt/kit": "^3.13.1",

--- a/playground/app/blokkli.editAdapter.ts
+++ b/playground/app/blokkli.editAdapter.ts
@@ -687,6 +687,17 @@ export default defineBlokkliEditAdapter((ctx) => {
       ])
     },
 
+    publish(options) {
+      if (options.closeAfterPublish) {
+        return Promise.resolve({
+          success: true,
+          state: null,
+          errors: [],
+        })
+      }
+      throw new Error('Publish is not supported on the demo page.')
+    },
+
     // @TODO: Implement in playground.
     // getLibraryItemEditUrl(uuid) {
     //   return 'http://localhost:3000/de?blokkliEditing=1'

--- a/src/runtime/adapter/drupal/graphql/base.graphql
+++ b/src/runtime/adapter/drupal/graphql/base.graphql
@@ -105,12 +105,13 @@ mutation pbPublish(
   $entityType: EntityType!
   $entityUuid: String!
   $langcode: String
+  $createNewState: Boolean
 ) {
   state: paragraphsEditMutationState(
     entityType: $entityType
     entityUuid: $entityUuid
   ) {
-    action: publish {
+    action: publish(createNewState: $createNewState) {
       ...paragraphsBlokkliMutationResult
     }
   }

--- a/src/runtime/adapter/drupal/graphqlMiddleware.ts
+++ b/src/runtime/adapter/drupal/graphqlMiddleware.ts
@@ -126,8 +126,11 @@ export default defineBlokkliEditAdapter<ParagraphsBlokkliEditStateFragment>(
         status,
       }).then(mapMutation)
 
-    const publish: DrupalAdapter['publish'] = () =>
-      useGraphqlMutation('pbPublish', ctx.value).then(mapMutation)
+    const publish: DrupalAdapter['publish'] = (options) =>
+      useGraphqlMutation('pbPublish', {
+        ...ctx.value,
+        createNewState: !options.closeAfterPublish,
+      }).then(mapMutation)
 
     const importFromExisting: DrupalAdapter['importFromExisting'] = (e) =>
       useGraphqlMutation('pbCopyFromExisting', {

--- a/src/runtime/adapter/index.ts
+++ b/src/runtime/adapter/index.ts
@@ -193,6 +193,18 @@ export type BlokkliAdapterGetLibraryItemsResult = {
   perPage: number
 }
 
+export type BlokkliAdapterPublishOptions = {
+  /**
+   * Whether the editor will be closed after publishing.
+   *
+   * If false, the adapter should return an empty state again, so that the
+   * editor UI shows the correct state (no pending changes).
+   * If true, the adapter may return no state at all, since the editor will
+   * be closed anyway after publishing.
+   */
+  closeAfterPublish?: boolean
+}
+
 export interface BlokkliAdapter<T> {
   /**
    * Load the state for the given langcode.
@@ -345,7 +357,9 @@ export interface BlokkliAdapter<T> {
   /**
    * Publish all changes.
    */
-  publish?: () => Promise<MutationResponseLike<T>>
+  publish?: (
+    options: BlokkliAdapterPublishOptions,
+  ) => Promise<MutationResponseLike<T | undefined | null>>
 
   /**
    * Set a specific history index.

--- a/src/runtime/components/Edit/Features/Publish/index.vue
+++ b/src/runtime/components/Edit/Features/Publish/index.vue
@@ -1,35 +1,76 @@
 <template>
   <PluginMenuButton
     id="publish"
-    :title="$t('publishLabel', 'Publish')"
-    :description="$t('publishDescription', 'Make all changes public')"
+    :title="publishLabel"
+    :description="publishDescription"
     :disabled="!mutations.length || !canEdit"
     type="success"
     :weight="0"
-    icon="publish"
+    :icon="icon"
     @click="onClick"
   />
 </template>
 
 <script lang="ts" setup>
-import { useBlokkli, defineBlokkliFeature } from '#imports'
+import { useBlokkli, defineBlokkliFeature, computed, useRoute } from '#imports'
 import { PluginMenuButton } from '#blokkli/plugins'
+import type { BlokkliIcon } from '#blokkli/icons'
 
-const { adapter } = defineBlokkliFeature({
+const { adapter, settings } = defineBlokkliFeature({
   id: 'publish',
   icon: 'publish',
   label: 'Publish',
   requiredAdapterMethods: ['publish'],
   description:
     'Provides a menu button to publish the changes of the current entity.',
+  settings: {
+    closeAfterPublish: {
+      type: 'checkbox',
+      label: 'Close editor after publishing',
+      default: true,
+      group: 'behavior',
+    },
+  },
 })
 
+const route = useRoute()
 const { state, $t, eventBus, broadcast, context } = useBlokkli()
 const { mutations, canEdit, mutateWithLoadingState } = state
 
+const isPublished = computed<boolean>(() => !!state.entity.value.status)
+
+const publishLabel = computed(() => {
+  // Entity is published. Clicking the button will make the changes go "live".
+  if (isPublished.value) {
+    return settings.value.closeAfterPublish
+      ? $t('publishAndCloseLabel', 'Publish & Close')
+      : $t('publishLabel', 'Publish')
+  }
+
+  return settings.value.closeAfterPublish
+    ? $t('publishAndCloseLabelUnpublished', 'Save & Close')
+    : $t('publishLabelUnpublished', 'Save')
+})
+
+const publishDescription = computed(() =>
+  isPublished.value
+    ? $t('publishDescription', 'Publish all changes.')
+    : $t(
+        'publishDescriptionUnpublished',
+        'Save all changes while keeping page unpublished',
+      ),
+)
+
+const icon = computed<BlokkliIcon>(() =>
+  isPublished.value ? 'publish' : 'save',
+)
+
 const onClick = async () => {
   const success = await mutateWithLoadingState(
-    adapter.publish,
+    () =>
+      adapter.publish({
+        closeAfterPublish: settings.value.closeAfterPublish,
+      }),
     $t('publishError', 'Changes could not be published.'),
     $t('publishSuccess', 'Changes published successfully.'),
   )
@@ -43,6 +84,10 @@ const onClick = async () => {
   }
 
   broadcast.emit('published', { uuid: context.value.entityUuid })
+
+  if (settings.value.closeAfterPublish) {
+    window.location.href = route.path
+  }
 }
 </script>
 

--- a/src/runtime/types/generatedModuleTypes.ts
+++ b/src/runtime/types/generatedModuleTypes.ts
@@ -27,6 +27,8 @@ export type ModuleOptionsSettings = {
     disable?: boolean
     default?: boolean
   }
+  // Close editor after publishing
+  'feature:publish:closeAfterPublish'?: { disable?: boolean; default?: boolean }
   // Enable low performance mode
   'feature:settings:lowPerformanceMode'?: {
     disable?: boolean

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -355,6 +355,10 @@
     "source": "Show import dialog at start when page is empty",
     "translation": "Importdialog beim Start anzeigen, wenn die Seite leer ist"
   },
+  "feature_publish_setting_closeAfterPublish_label": {
+    "source": "Close editor after publishing",
+    "translation": "Nach «Veröffentlichen» den Editor schliessen"
+  },
   "feature_settings_setting_lowPerformanceMode_label": {
     "source": "Enable low performance mode",
     "translation": "Modus für niedrige Leistung aktivieren"
@@ -695,9 +699,21 @@
     "source": "Shows a QR code to quickly open a preview of the changes with your smartphone.",
     "translation": "Zeigt einen QR-Code an, um eine Vorschau der Änderungen mit Ihrem Smartphone zu öffnen."
   },
+  "publishAndCloseLabel": {
+    "source": "Publish & Close",
+    "translation": "Veröffentlichen & Schliessen"
+  },
+  "publishAndCloseLabelUnpublished": {
+    "source": "Save & Close",
+    "translation": "Speichern & Schliessen"
+  },
   "publishDescription": {
-    "source": "Make all changes public",
-    "translation": "Alle Änderungen öffentlich machen"
+    "source": "Publish all changes.",
+    "translation": "Alle Änderungen veröffentlichen"
+  },
+  "publishDescriptionUnpublished": {
+    "source": "Save all changes while keeping page unpublished",
+    "translation": "Alle Änderungen speichern ohne die Seite zu publizieren"
   },
   "publishError": {
     "source": "Changes could not be published.",
@@ -706,6 +722,10 @@
   "publishLabel": {
     "source": "Publish",
     "translation": "Veröffentlichen"
+  },
+  "publishLabelUnpublished": {
+    "source": "Save",
+    "translation": "Speichern"
   },
   "publishSuccess": {
     "source": "Changes published successfully.",
@@ -741,7 +761,7 @@
   },
   "revertMenuDescription": {
     "source": "Restore currently published state",
-    "translation": "Aktuell veröffentlichter Zustand Wiederherstellen"
+    "translation": "Aktuell veröffentlichten Zustand wiederherstellen"
   },
   "revertMenuTitle": {
     "source": "Discard...",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -355,6 +355,10 @@
     "source": "Show import dialog at start when page is empty",
     "translation": ""
   },
+  "feature_publish_setting_closeAfterPublish_label": {
+    "source": "Close editor after publishing",
+    "translation": ""
+  },
   "feature_settings_setting_lowPerformanceMode_label": {
     "source": "Enable low performance mode",
     "translation": ""
@@ -695,9 +699,21 @@
     "source": "Shows a QR code to quickly open a preview of the changes with your smartphone.",
     "translation": ""
   },
+  "publishAndCloseLabel": {
+    "source": "Publish & Close",
+    "translation": ""
+  },
+  "publishAndCloseLabelUnpublished": {
+    "source": "Save & Close",
+    "translation": ""
+  },
   "publishDescription": {
-    "source": "Make all changes public",
+    "source": "Publish all changes.",
     "translation": "Rendre toutes les modifications publiques"
+  },
+  "publishDescriptionUnpublished": {
+    "source": "Save all changes while keeping page unpublished",
+    "translation": ""
   },
   "publishError": {
     "source": "Changes could not be published.",
@@ -706,6 +722,10 @@
   "publishLabel": {
     "source": "Publish",
     "translation": "Publier"
+  },
+  "publishLabelUnpublished": {
+    "source": "Save",
+    "translation": ""
   },
   "publishSuccess": {
     "source": "Changes published successfully.",

--- a/src/translations/gsw_CH.json
+++ b/src/translations/gsw_CH.json
@@ -355,6 +355,10 @@
     "source": "Show import dialog at start when page is empty",
     "translation": "Importdialog bim Start aazeige wenn d'Sitte leer isch"
   },
+  "feature_publish_setting_closeAfterPublish_label": {
+    "source": "Close editor after publishing",
+    "translation": ""
+  },
   "feature_settings_setting_lowPerformanceMode_label": {
     "source": "Enable low performance mode",
     "translation": ""
@@ -695,9 +699,21 @@
     "source": "Shows a QR code to quickly open a preview of the changes with your smartphone.",
     "translation": ""
   },
+  "publishAndCloseLabel": {
+    "source": "Publish & Close",
+    "translation": ""
+  },
+  "publishAndCloseLabelUnpublished": {
+    "source": "Save & Close",
+    "translation": ""
+  },
   "publishDescription": {
-    "source": "Make all changes public",
+    "source": "Publish all changes.",
     "translation": "Alli änderige öffentlich mache."
+  },
+  "publishDescriptionUnpublished": {
+    "source": "Save all changes while keeping page unpublished",
+    "translation": ""
   },
   "publishError": {
     "source": "Changes could not be published.",
@@ -706,6 +722,10 @@
   "publishLabel": {
     "source": "Publish",
     "translation": "Publiziere"
+  },
+  "publishLabelUnpublished": {
+    "source": "Save",
+    "translation": ""
   },
   "publishSuccess": {
     "source": "Changes published successfully.",

--- a/src/translations/it.json
+++ b/src/translations/it.json
@@ -355,6 +355,10 @@
     "source": "Show import dialog at start when page is empty",
     "translation": ""
   },
+  "feature_publish_setting_closeAfterPublish_label": {
+    "source": "Close editor after publishing",
+    "translation": ""
+  },
   "feature_settings_setting_lowPerformanceMode_label": {
     "source": "Enable low performance mode",
     "translation": ""
@@ -695,9 +699,21 @@
     "source": "Shows a QR code to quickly open a preview of the changes with your smartphone.",
     "translation": ""
   },
+  "publishAndCloseLabel": {
+    "source": "Publish & Close",
+    "translation": ""
+  },
+  "publishAndCloseLabelUnpublished": {
+    "source": "Save & Close",
+    "translation": ""
+  },
   "publishDescription": {
-    "source": "Make all changes public",
+    "source": "Publish all changes.",
     "translation": "Rendi pubbliche tutte le modifiche"
+  },
+  "publishDescriptionUnpublished": {
+    "source": "Save all changes while keeping page unpublished",
+    "translation": ""
   },
   "publishError": {
     "source": "Changes could not be published.",
@@ -706,6 +722,10 @@
   "publishLabel": {
     "source": "Publish",
     "translation": "Pubblica"
+  },
+  "publishLabelUnpublished": {
+    "source": "Save",
+    "translation": ""
   },
   "publishSuccess": {
     "source": "Changes published successfully.",


### PR DESCRIPTION
Also adds different publish label/description if the page entity is unpublished