### PR TITLE
feat: Built-in options to hide blocks for certain languages

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -407,4 +407,8 @@ html.bk-hide-non-editable {
   svg {
     @apply select-none;
   }
+
+  [data-bk-is-muted='true'] {
+    @apply opacity-30;
+  }
 }

--- a/css/partials/options.css
+++ b/css/partials/options.css
@@ -247,6 +247,13 @@
   .bk-blokkli-item-options-checkboxes {
     @apply px-15 h-full;
 
+    &.bk-is-grouped {
+      @apply h-auto px-0;
+      > div {
+        @apply static;
+      }
+    }
+
     @media not all and (hover: none) {
       @apply hover:bg-mono-700;
     }
@@ -377,6 +384,14 @@
     }
     .bk-blokkli-item-options-item-content {
       @apply h-50;
+
+      &.bk-is-grouped {
+        @apply h-auto;
+
+        .bk-blokkli-item-options-checkbox {
+          @apply h-50 w-full;
+        }
+      }
     }
 
     .bk-blokkli-item-options-item {

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -195,6 +195,10 @@ export default defineConfig({
           { text: 'defineBlokkli()', link: '/define-blokkli' },
           { text: 'Options', link: '/define-blokkli/options' },
           {
+            text: 'Built-in Options',
+            link: '/define-blokkli/built-in-options',
+          },
+          {
             text: 'Context based rendering',
             link: '/define-blokkli/render-for',
           },

--- a/docs/define-blokkli/built-in-options.md
+++ b/docs/define-blokkli/built-in-options.md
@@ -1,0 +1,35 @@
+# Built-in Options
+
+blökkli includes _global options_ that offer additional functionality beyond
+what's possible using custom options.
+
+## `bkVisibleLanguages` - Conditionally show a block per language
+
+This option renders a dropdown with checkboxes to select for which languages a
+block should be visible. If no languages are selected the block will be visible
+for all languages. The behaviour changes once one or more languages are
+selected:
+
+- Within the editor the DOM element will be displayed translucent to indicate
+  that the block won't be visible in the current language
+- Outside the editor the entire block component will not render if it's not
+  enabled for the current language
+
+The option is implemented as a [checkboxes](/define-blokkli/options#checkboxes)
+option. The data is therefore stored as a comma-separated string.
+
+The available language options are determined at runtime based on the available
+languages for the current page entity.
+
+### Enabling the Option
+
+You can enable the option like any global option:
+
+```vue [~/components/Blocks/Card.vue]
+<script lang="ts" setup>
+const { options } = defineBlokkli({
+  bundle: 'card',
+  globalOptions: ['bkVisibleLanguages'],
+})
+</script>
+```

--- a/i18n/de.po
+++ b/i18n/de.po
@@ -139,6 +139,14 @@ msgctxt "blockAddListTourTitle"
 msgid "Favorite blocks"
 msgstr "Favoriten-Blöcke"
 
+msgctxt "blockOption_bkHiddenGlobally_label"
+msgid "Hide globally"
+msgstr "Global verstecken"
+
+msgctxt "blockOption_bkVisibleLanguages_label"
+msgid "Visible languages"
+msgstr "Sichtbare Sprachen"
+
 msgctxt "cancel"
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -707,6 +715,10 @@ msgstr "Suchen Sie nach Medien wie Bildern und ziehen Sie diese in die Seite."
 msgctxt "multipleItemsLabel"
 msgid "Items"
 msgstr "Elemente"
+
+msgctxt "optionBkVisibleLanguagesAll"
+msgid "All languages"
+msgstr "Alle Sprachen"
 
 msgctxt "optionsCommand.selectCheckboxValue"
 msgid "Select \"@value\" in \"@option\""

--- a/i18n/de.po
+++ b/i18n/de.po
@@ -405,6 +405,10 @@ msgctxt "feature_import-existing_setting_showDialogWhenEmpty_label"
 msgid "Show import dialog at start when page is empty"
 msgstr "Importdialog beim Start anzeigen, wenn die Seite leer ist"
 
+msgctxt "feature_publish_setting_closeAfterPublish_label"
+msgid "Close editor after publishing"
+msgstr "Nach «Veröffentlichen» den Editor schliessen"
+
 msgctxt "feature_settings_setting_lowPerformanceMode_label"
 msgid "Enable low performance mode"
 msgstr "Modus für niedrige Leistung aktivieren"
@@ -780,9 +784,21 @@ msgstr ""
 "Zeigt einen QR-Code an, um eine Vorschau der Änderungen mit Ihrem "
 "Smartphone zu öffnen."
 
+msgctxt "publishAndCloseLabel"
+msgid "Publish & Close"
+msgstr "Veröffentlichen & Schliessen"
+
+msgctxt "publishAndCloseLabelUnpublished"
+msgid "Save & Close"
+msgstr "Speichern & Schliessen"
+
 msgctxt "publishDescription"
-msgid "Make all changes public"
-msgstr "Alle Änderungen öffentlich machen"
+msgid "Publish all changes."
+msgstr "Alle Änderungen veröffentlichen"
+
+msgctxt "publishDescriptionUnpublished"
+msgid "Save all changes while keeping page unpublished"
+msgstr "Alle Änderungen speichern ohne die Seite zu publizieren"
 
 msgctxt "publishError"
 msgid "Changes could not be published."
@@ -791,6 +807,10 @@ msgstr "Änderungen konnten nicht publiziert werden."
 msgctxt "publishLabel"
 msgid "Publish"
 msgstr "Veröffentlichen"
+
+msgctxt "publishLabelUnpublished"
+msgid "Save"
+msgstr "Speichern"
 
 msgctxt "publishSuccess"
 msgid "Changes published successfully."
@@ -836,7 +856,7 @@ msgstr "Änderungen konnten nicht verworfen werden."
 
 msgctxt "revertMenuDescription"
 msgid "Restore currently published state"
-msgstr "Aktuell veröffentlichter Zustand Wiederherstellen"
+msgstr "Aktuell veröffentlichten Zustand wiederherstellen"
 
 msgctxt "revertMenuTitle"
 msgid "Discard..."

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -391,6 +391,10 @@ msgctxt "feature_import-existing_setting_showDialogWhenEmpty_label"
 msgid "Show import dialog at start when page is empty"
 msgstr ""
 
+msgctxt "feature_publish_setting_closeAfterPublish_label"
+msgid "Close editor after publishing"
+msgstr ""
+
 msgctxt "feature_settings_setting_lowPerformanceMode_label"
 msgid "Enable low performance mode"
 msgstr ""
@@ -753,9 +757,21 @@ msgid ""
 "smartphone."
 msgstr ""
 
+msgctxt "publishAndCloseLabel"
+msgid "Publish & Close"
+msgstr ""
+
+msgctxt "publishAndCloseLabelUnpublished"
+msgid "Save & Close"
+msgstr ""
+
 msgctxt "publishDescription"
-msgid "Make all changes public"
+msgid "Publish all changes."
 msgstr "Rendre toutes les modifications publiques"
+
+msgctxt "publishDescriptionUnpublished"
+msgid "Save all changes while keeping page unpublished"
+msgstr ""
 
 msgctxt "publishError"
 msgid "Changes could not be published."
@@ -764,6 +780,10 @@ msgstr "Les modifications n’ont pas pu être publiées."
 msgctxt "publishLabel"
 msgid "Publish"
 msgstr "Publier"
+
+msgctxt "publishLabelUnpublished"
+msgid "Save"
+msgstr ""
 
 msgctxt "publishSuccess"
 msgid "Changes published successfully."

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -129,6 +129,14 @@ msgctxt "blockAddListTourTitle"
 msgid "Favorite blocks"
 msgstr ""
 
+msgctxt "blockOption_bkHiddenGlobally_label"
+msgid "Hide globally"
+msgstr ""
+
+msgctxt "blockOption_bkVisibleLanguages_label"
+msgid "Visible languages"
+msgstr ""
+
 msgctxt "cancel"
 msgid "Cancel"
 msgstr "Annuler"
@@ -682,6 +690,10 @@ msgstr ""
 msgctxt "multipleItemsLabel"
 msgid "Items"
 msgstr "Éléments"
+
+msgctxt "optionBkVisibleLanguagesAll"
+msgid "All languages"
+msgstr ""
 
 msgctxt "optionsCommand.selectCheckboxValue"
 msgid "Select \"@value\" in \"@option\""

--- a/i18n/gsw_CH.po
+++ b/i18n/gsw_CH.po
@@ -386,6 +386,10 @@ msgctxt "feature_import-existing_setting_showDialogWhenEmpty_label"
 msgid "Show import dialog at start when page is empty"
 msgstr "Importdialog bim Start aazeige wenn d'Sitte leer isch"
 
+msgctxt "feature_publish_setting_closeAfterPublish_label"
+msgid "Close editor after publishing"
+msgstr ""
+
 msgctxt "feature_settings_setting_lowPerformanceMode_label"
 msgid "Enable low performance mode"
 msgstr ""
@@ -751,9 +755,21 @@ msgid ""
 "smartphone."
 msgstr ""
 
+msgctxt "publishAndCloseLabel"
+msgid "Publish & Close"
+msgstr ""
+
+msgctxt "publishAndCloseLabelUnpublished"
+msgid "Save & Close"
+msgstr ""
+
 msgctxt "publishDescription"
-msgid "Make all changes public"
+msgid "Publish all changes."
 msgstr "Alli änderige öffentlich mache."
+
+msgctxt "publishDescriptionUnpublished"
+msgid "Save all changes while keeping page unpublished"
+msgstr ""
 
 msgctxt "publishError"
 msgid "Changes could not be published."
@@ -762,6 +778,10 @@ msgstr "D'Änderige hän nid chönne publiziert wärde."
 msgctxt "publishLabel"
 msgid "Publish"
 msgstr "Publiziere"
+
+msgctxt "publishLabelUnpublished"
+msgid "Save"
+msgstr ""
 
 msgctxt "publishSuccess"
 msgid "Changes published successfully."

--- a/i18n/gsw_CH.po
+++ b/i18n/gsw_CH.po
@@ -129,6 +129,14 @@ msgctxt "blockAddListTourTitle"
 msgid "Favorite blocks"
 msgstr ""
 
+msgctxt "blockOption_bkHiddenGlobally_label"
+msgid "Hide globally"
+msgstr ""
+
+msgctxt "blockOption_bkVisibleLanguages_label"
+msgid "Visible languages"
+msgstr ""
+
 msgctxt "cancel"
 msgid "Cancel"
 msgstr "Abbräche"
@@ -680,6 +688,10 @@ msgstr ""
 msgctxt "multipleItemsLabel"
 msgid "Items"
 msgstr "Elemänt"
+
+msgctxt "optionBkVisibleLanguagesAll"
+msgid "All languages"
+msgstr ""
 
 msgctxt "optionsCommand.selectCheckboxValue"
 msgid "Select \"@value\" in \"@option\""

--- a/i18n/it.po
+++ b/i18n/it.po
@@ -129,6 +129,14 @@ msgctxt "blockAddListTourTitle"
 msgid "Favorite blocks"
 msgstr ""
 
+msgctxt "blockOption_bkHiddenGlobally_label"
+msgid "Hide globally"
+msgstr ""
+
+msgctxt "blockOption_bkVisibleLanguages_label"
+msgid "Visible languages"
+msgstr ""
+
 msgctxt "cancel"
 msgid "Cancel"
 msgstr "Annulla"
@@ -682,6 +690,10 @@ msgstr ""
 msgctxt "multipleItemsLabel"
 msgid "Items"
 msgstr "Elementi"
+
+msgctxt "optionBkVisibleLanguagesAll"
+msgid "All languages"
+msgstr ""
 
 msgctxt "optionsCommand.selectCheckboxValue"
 msgid "Select \"@value\" in \"@option\""

--- a/i18n/it.po
+++ b/i18n/it.po
@@ -391,6 +391,10 @@ msgctxt "feature_import-existing_setting_showDialogWhenEmpty_label"
 msgid "Show import dialog at start when page is empty"
 msgstr ""
 
+msgctxt "feature_publish_setting_closeAfterPublish_label"
+msgid "Close editor after publishing"
+msgstr ""
+
 msgctxt "feature_settings_setting_lowPerformanceMode_label"
 msgid "Enable low performance mode"
 msgstr ""
@@ -753,9 +757,21 @@ msgid ""
 "smartphone."
 msgstr ""
 
+msgctxt "publishAndCloseLabel"
+msgid "Publish & Close"
+msgstr ""
+
+msgctxt "publishAndCloseLabelUnpublished"
+msgid "Save & Close"
+msgstr ""
+
 msgctxt "publishDescription"
-msgid "Make all changes public"
+msgid "Publish all changes."
 msgstr "Rendi pubbliche tutte le modifiche"
+
+msgctxt "publishDescriptionUnpublished"
+msgid "Save all changes while keeping page unpublished"
+msgstr ""
 
 msgctxt "publishError"
 msgid "Changes could not be published."
@@ -764,6 +780,10 @@ msgstr "Le modifiche non possono essere pubblicate."
 msgctxt "publishLabel"
 msgid "Publish"
 msgstr "Pubblica"
+
+msgctxt "publishLabelUnpublished"
+msgid "Save"
+msgstr ""
 
 msgctxt "publishSuccess"
 msgid "Changes published successfully."

--- a/playground/app/blokkli.editAdapter.ts
+++ b/playground/app/blokkli.editAdapter.ts
@@ -687,6 +687,10 @@ export default defineBlokkliEditAdapter((ctx) => {
       ])
     },
 
+    publish() {
+      throw new Error('Publish is not supported on the demo page.')
+    },
+
     // @TODO: Implement in playground.
     // getLibraryItemEditUrl(uuid) {
     //   return 'http://localhost:3000/de?blokkliEditing=1'

--- a/playground/app/blokkli.editAdapter.ts
+++ b/playground/app/blokkli.editAdapter.ts
@@ -166,7 +166,7 @@ export default defineBlokkliEditAdapter((ctx) => {
         entity: {
           id: ctx.value.entityUuid,
           label: 'Demo Page',
-          status: true,
+          status: false,
           bundleLabel: 'Page',
         },
         translationState: {

--- a/playground/components/Blokkli/Title/Title.vue
+++ b/playground/components/Blokkli/Title/Title.vue
@@ -37,6 +37,7 @@
 import { defineBlokkli, computed, inject, type ComputedRef } from '#imports'
 const { parentType, fieldListType, uuid } = defineBlokkli({
   bundle: 'title',
+  globalOptions: ['bkHiddenGlobally', 'bkVisibleLanguages'],
   options: {
     showInMenu: {
       type: 'checkbox',

--- a/scripts/texts/app.ts
+++ b/scripts/texts/app.ts
@@ -1,12 +1,21 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { BaseCallExpression, Expression, SpreadElement } from 'estree'
+import type { BaseCallExpression, Expression, SpreadElement } from 'estree'
 import { parse } from 'acorn'
 import chalk from 'chalk'
 import { glob } from 'glob'
 import { format } from './../helpers'
 import { sortObjectKeys } from './../../src/helpers'
 import { po as PO, type GetTextTranslation } from 'gettext-parser'
+import {
+  BK_HIDDEN_GLOBALLY,
+  BK_VISIBLE_LANGUAGES,
+} from '../../src/runtime/helpers/symbols'
+
+const INTERNAL_TRANSLATIONS = {
+  [`blockOption_${BK_VISIBLE_LANGUAGES}_label`]: 'Visible languages',
+  [`blockOption_${BK_HIDDEN_GLOBALLY}_label`]: 'Hide globally',
+}
 
 const LANGUAGES = ['de', 'fr', 'it', 'gsw_CH']
 
@@ -361,7 +370,11 @@ async function generatePO(
 async function main() {
   const sourceTexts = await getSourceTexts()
 
-  await Promise.all(LANGUAGES.map((v) => updateTranslationFile(v, sourceTexts)))
+  await Promise.all(
+    LANGUAGES.map((v) =>
+      updateTranslationFile(v, { ...sourceTexts, ...INTERNAL_TRANSLATIONS }),
+    ),
+  )
 }
 
 main()

--- a/src/Extractor/BlockExtractor.ts
+++ b/src/Extractor/BlockExtractor.ts
@@ -9,7 +9,7 @@ import { sortObjectKeys } from './../helpers'
 import { defu } from 'defu'
 import { falsy } from '../vitePlugin'
 
-type ExtractedBlockDefinitionInput = BlockDefinitionInput
+type ExtractedBlockDefinitionInput = BlockDefinitionInput<any, any>
 type ExtractedFragmentDefinitionInput = FragmentDefinitionInput
 
 type ExtractedDefinition = {
@@ -342,12 +342,23 @@ export const getFragmentDefinition = (name: string): FragmentDefinitionInput<Rec
       },
       {},
     )
+    const bundlesWithVisibleLanguage = Object.values(this.definitions)
+      .map((definition) => {
+        if (
+          definition?.definition.globalOptions?.includes('bkVisibleLanguages')
+        ) {
+          return definition.definition.bundle
+        }
+      })
+      .filter(falsy)
     return `import type { BlockOptionDefinition } from '#blokkli/types/blokkOptions'
 
 type GlobalOptionsDefaults = {
   type: BlockOptionDefinition['type']
   default: any
 }
+
+export const bundlesWithVisibleLanguage = ${JSON.stringify(bundlesWithVisibleLanguage)}
 
 export const globalOptionsDefaults: Record<string, GlobalOptionsDefaults> = ${JSON.stringify(
       defaults,

--- a/src/Extractor/BlockExtractor.ts
+++ b/src/Extractor/BlockExtractor.ts
@@ -313,7 +313,7 @@ export const getFragmentDefinition = (name: string): FragmentDefinitionInput<Rec
         const existing = acc[v.definition.bundle] || {}
         acc[v.definition.bundle] = defu(existing, v.definition.options || {})
 
-        const globalOptionKeys = v.definition.globalOptions || []
+        const globalOptionKeys: string[] = v.definition.globalOptions || []
 
         globalOptionKeys.forEach((name) => {
           if (globalOptions[name]) {

--- a/src/Extractor/BlockExtractor.ts
+++ b/src/Extractor/BlockExtractor.ts
@@ -8,6 +8,10 @@ import type {
 import { sortObjectKeys } from './../helpers'
 import { defu } from 'defu'
 import { falsy } from '../vitePlugin'
+import {
+  BK_HIDDEN_GLOBALLY,
+  BK_VISIBLE_LANGUAGES,
+} from './../runtime/helpers/symbols'
 
 type ExtractedBlockDefinitionInput = BlockDefinitionInput<any, any>
 type ExtractedFragmentDefinitionInput = FragmentDefinitionInput
@@ -324,6 +328,16 @@ export const getFragmentDefinition = (name: string): FragmentDefinitionInput<Rec
     return JSON.stringify(sorted, null, 2)
   }
 
+  getBundlesWithGlobalOptions(key: string) {
+    return Object.values(this.definitions)
+      .map((definition) => {
+        if (definition?.definition.globalOptions?.includes(key)) {
+          return definition.definition.bundle
+        }
+      })
+      .filter(falsy)
+  }
+
   /**
    * Generate the default global options values template.
    */
@@ -342,15 +356,6 @@ export const getFragmentDefinition = (name: string): FragmentDefinitionInput<Rec
       },
       {},
     )
-    const bundlesWithVisibleLanguage = Object.values(this.definitions)
-      .map((definition) => {
-        if (
-          definition?.definition.globalOptions?.includes('bkVisibleLanguages')
-        ) {
-          return definition.definition.bundle
-        }
-      })
-      .filter(falsy)
     return `import type { BlockOptionDefinition } from '#blokkli/types/blokkOptions'
 
 type GlobalOptionsDefaults = {
@@ -358,7 +363,8 @@ type GlobalOptionsDefaults = {
   default: any
 }
 
-export const bundlesWithVisibleLanguage = ${JSON.stringify(bundlesWithVisibleLanguage)}
+export const bundlesWithVisibleLanguage = ${JSON.stringify(this.getBundlesWithGlobalOptions(BK_VISIBLE_LANGUAGES))}
+export const bundlesWithHiddenGlobally = ${JSON.stringify(this.getBundlesWithGlobalOptions(BK_HIDDEN_GLOBALLY))}
 
 export const globalOptionsDefaults: Record<string, GlobalOptionsDefaults> = ${JSON.stringify(
       defaults,

--- a/src/module.ts
+++ b/src/module.ts
@@ -24,6 +24,10 @@ import defaultTranslations from './translations'
 import { getTheme, themes } from './themes'
 import type { ThemeName, RGB, Theme } from './runtime/types/theme'
 import type { ModuleOptionsSettings } from '#blokkli/types/generatedModuleTypes'
+import {
+  BK_HIDDEN_GLOBALLY,
+  BK_VISIBLE_LANGUAGES,
+} from './runtime/helpers/symbols'
 
 function hexToRgb(hex: string): RGB {
   // Remove the hash symbol if present
@@ -262,13 +266,13 @@ export default defineNuxtModule<ModuleOptions>({
   defaults: {
     pattern: ['components/Blokkli/**/*.{js,ts,vue}'],
     globalOptions: {
-      bkVisibleLanguages: {
+      [BK_VISIBLE_LANGUAGES]: {
         type: 'checkboxes',
         label: 'Visible languages',
         options: {},
         default: [],
       },
-      bkHiddenGlobally: {
+      [BK_HIDDEN_GLOBALLY]: {
         type: 'checkbox',
         label: 'Hide globally',
         default: false,

--- a/src/module.ts
+++ b/src/module.ts
@@ -261,7 +261,19 @@ export default defineNuxtModule<ModuleOptions>({
   },
   defaults: {
     pattern: ['components/Blokkli/**/*.{js,ts,vue}'],
-    globalOptions: {} as BlockDefinitionOptionsInput,
+    globalOptions: {
+      bkVisibleLanguages: {
+        type: 'checkboxes',
+        label: 'Visible languages',
+        options: {},
+        default: [],
+      },
+      bkHiddenGlobally: {
+        type: 'checkbox',
+        label: 'Hide globally',
+        default: false,
+      },
+    },
     chunkNames: ['global'] as string[],
     itemEntityType: 'block',
   },

--- a/src/runtime/components/BlokkliField.vue
+++ b/src/runtime/components/BlokkliField.vue
@@ -12,6 +12,7 @@
     :field-list-type="fieldListType"
     :class="[attrs.class, listClass, { [nonEmptyClass]: filteredList.length }]"
     :is-nested="isNested"
+    :language="providerEntity.language"
     class="bk-field-list"
     :tag="tag"
   />

--- a/src/runtime/components/BlokkliField.vue
+++ b/src/runtime/components/BlokkliField.vue
@@ -43,7 +43,7 @@
 <script lang="ts" setup>
 import { computed, useAttrs, inject, provide, ref } from '#imports'
 import type { BlokkliFragmentName } from '#blokkli/definitions'
-import { bundlesWithVisibleLanguage } from '#blokkli/default-global-options'
+import { isVisibleByOptions } from '#blokkli/helpers/runtimeHelpers'
 import BlokkliItem from './BlokkliItem.vue'
 
 import type {
@@ -139,24 +139,11 @@ const fieldKey = computed<string | undefined>(() => {
 const fieldListType = computed(() => props.fieldListType)
 
 function filterVisible(item?: FieldListItemTyped): boolean {
-  const option = item?.options?.bkVisibleLanguages
-  if (
-    !isEditing &&
-    typeof option === 'string' &&
-    item.bundle &&
-    bundlesWithVisibleLanguage.includes(item.bundle)
-  ) {
-    const languages = option.split(',').filter(Boolean)
-
-    if (
-      languages.length &&
-      !languages.includes(providerEntity.value.language)
-    ) {
-      return false
-    }
+  // The block is always rendered during editing.
+  if (isEditing) {
+    return true
   }
-
-  return true
+  return isVisibleByOptions(item, providerEntity.value.language)
 }
 
 const filteredList = computed<FieldListItemTyped[]>(() => {
@@ -174,6 +161,7 @@ const filteredList = computed<FieldListItemTyped[]>(() => {
       })
       .filter(filterVisible)
   }
+
   const list = Array.isArray(props.list) ? props.list : [props.list]
   return list.filter(filterVisible) as FieldListItemTyped[]
 })

--- a/src/runtime/components/BlokkliProvider.vue
+++ b/src/runtime/components/BlokkliProvider.vue
@@ -68,7 +68,11 @@ import {
   ref,
   onMounted,
 } from '#imports'
-import { INJECT_ENTITY_CONTEXT } from '../helpers/symbols'
+import {
+  INJECT_ENTITY_CONTEXT,
+  INJECT_PROVIDER_CONTEXT,
+} from '../helpers/symbols'
+import type { BlokkliProviderEntityContext } from '#blokkli/types'
 
 const PreviewProvider = defineAsyncComponent(
   () => import('./Edit/PreviewProvider.vue'),
@@ -148,6 +152,18 @@ function edit() {
   })
 }
 
+const blokkliProviderEntityContext = computed<BlokkliProviderEntityContext>(
+  () => {
+    return {
+      uuid: props.entityUuid,
+      type: props.entityType,
+      bundle: props.entityBundle,
+      language: props.language,
+    }
+  },
+)
+
+provide(INJECT_PROVIDER_CONTEXT, blokkliProviderEntityContext)
 provide(INJECT_ENTITY_CONTEXT, {
   uuid: props.entityUuid,
   type: props.entityType,

--- a/src/runtime/components/Edit/DraggableList.vue
+++ b/src/runtime/components/Edit/DraggableList.vue
@@ -42,6 +42,7 @@
       :data-is-nested="isNested"
       :data-is-new="item.isNew"
       :data-entity-type="runtimeConfig.itemEntityType"
+      :data-bk-is-muted="isMuted(item.options)"
     />
   </Component>
 </template>
@@ -61,6 +62,7 @@ const props = defineProps<{
   fieldKey: string
   list: FieldListItem[]
   entity: EntityContext
+  language: string
   tag?: string
   isNested: boolean
   fieldListType: string
@@ -97,6 +99,23 @@ const allowedBundles = computed<string>(() => {
 
   return bundles.join(',')
 })
+
+// @TODO: This should be handled differently to prevent constant updates in the
+// component when the options change.
+// Ideally this is handled as an overlay on top of the blocks, similar to how
+// selection or multi-select works.
+function isMuted(options?: Record<string, any>) {
+  if (
+    options &&
+    typeof options === 'object' &&
+    'bkVisibleLanguages' in options
+  ) {
+    const languages: string[] = options.bkVisibleLanguages.split(',')
+    return languages.length && !languages.includes(props.language)
+  }
+
+  return false
+}
 
 onMounted(() => {
   if (root.value) {

--- a/src/runtime/components/Edit/DraggableList.vue
+++ b/src/runtime/components/Edit/DraggableList.vue
@@ -42,7 +42,7 @@
       :data-is-nested="isNested"
       :data-is-new="item.isNew"
       :data-entity-type="runtimeConfig.itemEntityType"
-      :data-bk-is-muted="isMuted(item.options)"
+      :data-bk-is-muted="isMuted(item)"
     />
   </Component>
 </template>
@@ -52,6 +52,7 @@ import { computed, useBlokkli, ref, onMounted, onBeforeUnmount } from '#imports'
 import type { FieldListItem, EntityContext, FieldConfig } from '#blokkli/types'
 import type { BlokkliFragmentName } from '#blokkli/definitions'
 import BlokkliItem from './../BlokkliItem.vue'
+import { isVisibleByOptions } from '#blokkli/helpers/runtimeHelpers'
 
 const { dom, types, runtimeConfig } = useBlokkli()
 
@@ -104,17 +105,8 @@ const allowedBundles = computed<string>(() => {
 // component when the options change.
 // Ideally this is handled as an overlay on top of the blocks, similar to how
 // selection or multi-select works.
-function isMuted(options?: Record<string, any>) {
-  if (
-    options &&
-    typeof options === 'object' &&
-    'bkVisibleLanguages' in options
-  ) {
-    const languages: string[] = options.bkVisibleLanguages.split(',')
-    return languages.length && !languages.includes(props.language)
-  }
-
-  return false
+function isMuted(item?: FieldListItem) {
+  return !isVisibleByOptions(item, props.language)
 }
 
 onMounted(() => {

--- a/src/runtime/components/Edit/Features/Options/Form/Checkboxes/index.vue
+++ b/src/runtime/components/Edit/Features/Options/Form/Checkboxes/index.vue
@@ -76,7 +76,7 @@ const checked = computed<string[]>({
 
 const visibleLabel = computed(() => {
   if (props.property === BK_VISIBLE_LANGUAGES && !checked.value.length) {
-    return $t('optionBkVisibleLanguagesAll', 'Always visible')
+    return $t('optionBkVisibleLanguagesAll', 'All languages')
   }
   return props.label
 })

--- a/src/runtime/components/Edit/Features/Options/Form/Checkboxes/index.vue
+++ b/src/runtime/components/Edit/Features/Options/Form/Checkboxes/index.vue
@@ -38,6 +38,7 @@
 import { computed, ref, useBlokkli } from '#imports'
 import { Icon } from '#blokkli/components'
 import defineCommands from '#blokkli/helpers/composables/defineCommands'
+import { BK_VISIBLE_LANGUAGES } from '#blokkli/helpers/symbols'
 
 const { $t, state } = useBlokkli()
 
@@ -74,7 +75,7 @@ const checked = computed<string[]>({
 })
 
 const visibleLabel = computed(() => {
-  if (props.property === 'bkVisibleLanguages' && !checked.value.length) {
+  if (props.property === BK_VISIBLE_LANGUAGES && !checked.value.length) {
     return $t('optionBkVisibleLanguagesAll', 'Always visible')
   }
   return props.label

--- a/src/runtime/components/Edit/Features/Options/Form/Item.vue
+++ b/src/runtime/components/Edit/Features/Options/Form/Item.vue
@@ -77,6 +77,7 @@ import OptionRange from './Range/index.vue'
 import OptionNumber from './Number/index.vue'
 import type { BlockOptionDefinition } from '#blokkli/types/blokkOptions'
 import { mapCheckboxTrue } from '#blokkli/helpers/runtimeHelpers'
+import { BK_VISIBLE_LANGUAGES } from '#blokkli/helpers/symbols'
 
 const { state } = useBlokkli()
 
@@ -106,7 +107,7 @@ const checkboxOptions = computed<{ value: string; label: string }[]>(() => {
     return []
   }
 
-  if (props.property === 'bkVisibleLanguages') {
+  if (props.property === BK_VISIBLE_LANGUAGES) {
     return (state.translation.value.availableLanguages || []).map(
       (language) => {
         return {

--- a/src/runtime/components/Edit/Features/Options/Form/Item.vue
+++ b/src/runtime/components/Edit/Features/Options/Form/Item.vue
@@ -4,7 +4,7 @@
       v-if="showLabel"
       :class="isGrouped ? 'bk-blokkli-item-options-item-label' : 'bk-tooltip'"
     >
-      <span>{{ option.label }}</span>
+      <span>{{ label }}</span>
     </div>
     <div
       class="bk-blokkli-item-options-item-content"
@@ -15,7 +15,7 @@
       <OptionRadios
         v-if="option.type === 'radios'"
         v-model="value"
-        :label="option.label"
+        :label="label"
         :options="option.options"
         :property="property"
         :display-as="option.displayAs"
@@ -24,14 +24,14 @@
         v-else-if="option.type === 'checkbox'"
         v-model="value"
         :property="property"
-        :label="option.label"
+        :label="label"
         :value="value"
       />
       <OptionCheckboxes
         v-else-if="option.type === 'checkboxes'"
         v-model="value"
         :property="property"
-        :label="option.label"
+        :label="label"
         :options="checkboxOptions"
         :value="value"
         :is-grouped="isGrouped"
@@ -39,18 +39,18 @@
       <OptionText
         v-else-if="option.type === 'text'"
         v-model="value"
-        :label="option.label"
+        :label="label"
         :type="option.inputType"
       />
       <OptionColor
         v-else-if="option.type === 'color'"
         v-model="value"
-        :label="option.label"
+        :label="label"
       />
       <OptionRange
         v-else-if="option.type === 'range'"
         v-model="value"
-        :label="option.label"
+        :label="label"
         :min="option.min"
         :max="option.max"
         :step="option.step"
@@ -58,7 +58,7 @@
       <OptionNumber
         v-else-if="option.type === 'number'"
         v-model="value"
-        :label="option.label"
+        :label="label"
         :min="option.min"
         :max="option.max"
       />
@@ -79,7 +79,7 @@ import type { BlockOptionDefinition } from '#blokkli/types/blokkOptions'
 import { mapCheckboxTrue } from '#blokkli/helpers/runtimeHelpers'
 import { BK_VISIBLE_LANGUAGES } from '#blokkli/helpers/symbols'
 
-const { state } = useBlokkli()
+const { state, $t: $blokkliText } = useBlokkli()
 
 const emit = defineEmits<{
   (e: 'update', data: string): void
@@ -101,6 +101,10 @@ const showLabel = computed(() => {
 
   return true
 })
+
+const label = computed(() =>
+  $blokkliText(`blockOption_${props.property}_label`, props.option.label),
+)
 
 const checkboxOptions = computed<{ value: string; label: string }[]>(() => {
   if (props.option.type !== 'checkboxes') {

--- a/src/runtime/components/Edit/Features/Options/Form/index.vue
+++ b/src/runtime/components/Edit/Features/Options/Form/index.vue
@@ -14,7 +14,8 @@
       class="bk-blokkli-item-options-item"
       :class="{
         'bk-is-disabled':
-          !state.canEdit.value || state.editMode.value !== 'editing',
+          (!state.canEdit.value || state.editMode.value !== 'editing') &&
+          plugin.property !== 'bkVisibleLanguages',
       }"
       @keydown.stop
       @update="setOptionValue(plugin.property, $event)"

--- a/src/runtime/components/Edit/Features/Options/Form/index.vue
+++ b/src/runtime/components/Edit/Features/Options/Form/index.vue
@@ -13,9 +13,7 @@
       :uuids="uuids"
       class="bk-blokkli-item-options-item"
       :class="{
-        'bk-is-disabled':
-          (!state.canEdit.value || state.editMode.value !== 'editing') &&
-          plugin.property !== 'bkVisibleLanguages',
+        'bk-is-disabled': isDisabled(plugin),
       }"
       @keydown.stop
       @update="setOptionValue(plugin.property, $event)"
@@ -36,8 +34,7 @@
         :uuids="uuids"
         class="bk-blokkli-item-options-item"
         :class="{
-          'bk-is-disabled':
-            !state.canEdit.value || state.editMode.value !== 'editing',
+          'bk-is-disabled': isDisabled(plugin),
         }"
         is-grouped
         @keydown.stop
@@ -61,6 +58,10 @@ import type {
 import type { BlockOptionDefinition } from '#blokkli/types/blokkOptions'
 import { optionValueToStorable } from '#blokkli/helpers/options'
 import { getRuntimeOptionValue } from '#blokkli/helpers/runtimeHelpers'
+import {
+  BK_HIDDEN_GLOBALLY,
+  BK_VISIBLE_LANGUAGES,
+} from '#blokkli/helpers/symbols'
 
 type OptionItem = {
   property: string
@@ -230,9 +231,21 @@ const currentValues = computed(() => {
   }, {})
 })
 
+function filterInternal(item: OptionItem) {
+  if (currentValues.value[BK_HIDDEN_GLOBALLY]) {
+    return item.property !== BK_VISIBLE_LANGUAGES
+  }
+
+  return true
+}
+
+function isInternalOption(property: string) {
+  return property === BK_VISIBLE_LANGUAGES || property === BK_HIDDEN_GLOBALLY
+}
+
 const visibleOptions = computed<OptionItem[]>(() => {
   if (!props.definition.editor?.determineVisibleOptions) {
-    return availableOptions.value
+    return availableOptions.value.filter(filterInternal)
   }
 
   const uuid = props.uuids[0]
@@ -262,8 +275,24 @@ const visibleOptions = computed<OptionItem[]>(() => {
       fieldListType: block?.hostFieldListType || 'default',
     })
 
-  return availableOptions.value.filter((v) => visibleKeys.includes(v.property))
+  return availableOptions.value
+    .filter(
+      (v) => isInternalOption(v.property) || visibleKeys.includes(v.property),
+    )
+    .filter(filterInternal)
 })
+
+function isDisabled(plugin: OptionItem) {
+  if (!state.canEdit.value || state.editMode.value === 'readonly') {
+    return true
+  }
+
+  if (isInternalOption(plugin.property)) {
+    return false
+  }
+
+  return state.editMode.value !== 'editing'
+}
 
 const singleVisibleOptions = computed(() =>
   visibleOptions.value.filter((v) => !v.option.group),

--- a/src/runtime/components/Edit/Features/Publish/index.vue
+++ b/src/runtime/components/Edit/Features/Publish/index.vue
@@ -1,31 +1,69 @@
 <template>
   <PluginMenuButton
     id="publish"
-    :title="$t('publishLabel', 'Publish')"
-    :description="$t('publishDescription', 'Make all changes public')"
+    :title="publishLabel"
+    :description="publishDescription"
     :disabled="!mutations.length || !canEdit"
     type="success"
     :weight="0"
-    icon="publish"
+    :icon="icon"
     @click="onClick"
   />
 </template>
 
 <script lang="ts" setup>
-import { useBlokkli, defineBlokkliFeature } from '#imports'
+import { useBlokkli, defineBlokkliFeature, computed, useRoute } from '#imports'
 import { PluginMenuButton } from '#blokkli/plugins'
+import type { BlokkliIcon } from '#blokkli/icons'
 
-const { adapter } = defineBlokkliFeature({
+const { adapter, settings } = defineBlokkliFeature({
   id: 'publish',
   icon: 'publish',
   label: 'Publish',
   requiredAdapterMethods: ['publish'],
   description:
     'Provides a menu button to publish the changes of the current entity.',
+  settings: {
+    closeAfterPublish: {
+      type: 'checkbox',
+      label: 'Close editor after publishing',
+      default: true,
+      group: 'behavior',
+    },
+  },
 })
 
+const route = useRoute()
 const { state, $t, eventBus, broadcast, context } = useBlokkli()
 const { mutations, canEdit, mutateWithLoadingState } = state
+
+const isPublished = computed<boolean>(() => !!state.entity.value.status)
+
+const publishLabel = computed(() => {
+  // Entity is published. Clicking the button will make the changes go "live".
+  if (isPublished.value) {
+    return settings.value.closeAfterPublish
+      ? $t('publishAndCloseLabel', 'Publish & Close')
+      : $t('publishLabel', 'Publish')
+  }
+
+  return settings.value.closeAfterPublish
+    ? $t('publishAndCloseLabelUnpublished', 'Save & Close')
+    : $t('publishLabelUnpublished', 'Save')
+})
+
+const publishDescription = computed(() =>
+  isPublished.value
+    ? $t('publishDescription', 'Publish all changes.')
+    : $t(
+        'publishDescriptionUnpublished',
+        'Save all changes while keeping page unpublished',
+      ),
+)
+
+const icon = computed<BlokkliIcon>(() =>
+  isPublished.value ? 'publish' : 'save',
+)
 
 const onClick = async () => {
   const success = await mutateWithLoadingState(
@@ -43,6 +81,10 @@ const onClick = async () => {
   }
 
   broadcast.emit('published', { uuid: context.value.entityUuid })
+
+  if (settings.value.closeAfterPublish) {
+    window.location.href = route.path
+  }
 }
 </script>
 

--- a/src/runtime/helpers/runtimeHelpers/index.ts
+++ b/src/runtime/helpers/runtimeHelpers/index.ts
@@ -2,7 +2,14 @@
  * This file should contain all helpers that are meant for runtime functionality, such as defineBlokkli composable or <BlokkliProvider>.
  */
 
+import type { FieldListItemTyped } from '#blokkli/generated-types'
 import type { BlockOptionDefinition } from '#blokkli/types/blokkOptions'
+import {
+  bundlesWithVisibleLanguage,
+  bundlesWithHiddenGlobally,
+} from '#blokkli/default-global-options'
+import type { FieldListItem } from '#blokkli/types'
+import { BK_HIDDEN_GLOBALLY, BK_VISIBLE_LANGUAGES } from '../symbols'
 
 /**
  * Map all kinds of truthy values for a checkbox.
@@ -51,4 +58,42 @@ export function getRuntimeOptionValue(
   }
 
   return ''
+}
+
+/**
+ * Determines whether an item is visible.
+ */
+export function isVisibleByOptions(
+  item?: FieldListItemTyped | FieldListItem,
+  language?: string,
+) {
+  // Make the method accept a nullable argument because field item lists may
+  // contain falsy values in their arrays.
+  if (!item) {
+    return false
+  }
+
+  if (item.options) {
+    // Hide if the "hidden globally" option is set.
+    if (
+      bundlesWithHiddenGlobally.includes(item.bundle) &&
+      mapCheckboxTrue(item.options[BK_HIDDEN_GLOBALLY]) === '1'
+    ) {
+      return false
+    }
+
+    // Hide if the bundle has the "visible languages" option enabled and if
+    // the current language is not included in the visible languages.
+    if (bundlesWithVisibleLanguage.includes(item.bundle)) {
+      const option = item.options[BK_VISIBLE_LANGUAGES]
+      if (language && option && typeof option === 'string') {
+        const languages = option.split(',')
+        if (languages.length && !languages.includes(language)) {
+          return false
+        }
+      }
+    }
+  }
+
+  return true
 }

--- a/src/runtime/helpers/symbols.ts
+++ b/src/runtime/helpers/symbols.ts
@@ -11,6 +11,7 @@ export const INJECT_PROVIDER_BLOCKS = Symbol('blokkli_provider_blocks')
 export const INJECT_BLOCK_ITEM = Symbol('blokkli_block_item')
 export const INJECT_MUTATED_FIELDS_MAP = Symbol('blokkli_mutated_fields_map')
 export const INJECT_ENTITY_CONTEXT = Symbol('blokkli_entity_context')
+export const INJECT_PROVIDER_CONTEXT = Symbol('blokkli_provider_context')
 export const INJECT_FRAGMENT_CONTEXT = Symbol('blokkli_fragment_context')
 export const INJECT_EDIT_FIELD_LIST_COMPONENT = Symbol(
   'blokkli_edit_field_list_component',

--- a/src/runtime/helpers/symbols.ts
+++ b/src/runtime/helpers/symbols.ts
@@ -17,3 +17,6 @@ export const INJECT_EDIT_FIELD_LIST_COMPONENT = Symbol(
   'blokkli_edit_field_list_component',
 )
 export const INJECT_EDIT_LOGGER = Symbol('blokkli_edit_logger')
+
+export const BK_HIDDEN_GLOBALLY = 'bkHiddenGlobally'
+export const BK_VISIBLE_LANGUAGES = 'bkVisibleLanguages'

--- a/src/runtime/types/generatedModuleTypes.ts
+++ b/src/runtime/types/generatedModuleTypes.ts
@@ -27,6 +27,8 @@ export type ModuleOptionsSettings = {
     disable?: boolean
     default?: boolean
   }
+  // Close editor after publishing
+  'feature:publish:closeAfterPublish'?: { disable?: boolean; default?: boolean }
   // Enable low performance mode
   'feature:settings:lowPerformanceMode'?: {
     disable?: boolean

--- a/src/runtime/types/index.ts
+++ b/src/runtime/types/index.ts
@@ -374,6 +374,13 @@ export type EntityContext = {
   bundle: string
 }
 
+export type BlokkliProviderEntityContext = {
+  uuid: string
+  type: string
+  bundle: string
+  language?: string
+}
+
 export type EditEntity = {
   label?: string
   status?: boolean

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -355,6 +355,10 @@
     "source": "Show import dialog at start when page is empty",
     "translation": "Importdialog beim Start anzeigen, wenn die Seite leer ist"
   },
+  "feature_publish_setting_closeAfterPublish_label": {
+    "source": "Close editor after publishing",
+    "translation": "Nach «Veröffentlichen» den Editor schliessen"
+  },
   "feature_settings_setting_lowPerformanceMode_label": {
     "source": "Enable low performance mode",
     "translation": "Modus für niedrige Leistung aktivieren"
@@ -695,9 +699,21 @@
     "source": "Shows a QR code to quickly open a preview of the changes with your smartphone.",
     "translation": "Zeigt einen QR-Code an, um eine Vorschau der Änderungen mit Ihrem Smartphone zu öffnen."
   },
+  "publishAndCloseLabel": {
+    "source": "Publish & Close",
+    "translation": "Veröffentlichen & Schliessen"
+  },
+  "publishAndCloseLabelUnpublished": {
+    "source": "Save & Close",
+    "translation": "Speichern & Schliessen"
+  },
   "publishDescription": {
-    "source": "Make all changes public",
-    "translation": "Alle Änderungen öffentlich machen"
+    "source": "Publish all changes.",
+    "translation": "Alle Änderungen veröffentlichen"
+  },
+  "publishDescriptionUnpublished": {
+    "source": "Save all changes while keeping page unpublished",
+    "translation": "Alle Änderungen speichern ohne die Seite zu publizieren"
   },
   "publishError": {
     "source": "Changes could not be published.",
@@ -706,6 +722,10 @@
   "publishLabel": {
     "source": "Publish",
     "translation": "Veröffentlichen"
+  },
+  "publishLabelUnpublished": {
+    "source": "Save",
+    "translation": "Speichern"
   },
   "publishSuccess": {
     "source": "Changes published successfully.",
@@ -741,7 +761,7 @@
   },
   "revertMenuDescription": {
     "source": "Restore currently published state",
-    "translation": "Aktuell veröffentlichter Zustand Wiederherstellen"
+    "translation": "Aktuell veröffentlichten Zustand wiederherstellen"
   },
   "revertMenuTitle": {
     "source": "Discard...",

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -119,6 +119,14 @@
     "source": "Favorite blocks",
     "translation": "Favoriten-Blöcke"
   },
+  "blockOption_bkHiddenGlobally_label": {
+    "source": "Hide globally",
+    "translation": "Global verstecken"
+  },
+  "blockOption_bkVisibleLanguages_label": {
+    "source": "Visible languages",
+    "translation": "Sichtbare Sprachen"
+  },
   "cancel": {
     "source": "Cancel",
     "translation": "Abbrechen"
@@ -630,6 +638,10 @@
   "multipleItemsLabel": {
     "source": "Items",
     "translation": "Elemente"
+  },
+  "optionBkVisibleLanguagesAll": {
+    "source": "All languages",
+    "translation": "Alle Sprachen"
   },
   "optionsCommand.selectCheckboxValue": {
     "source": "Select \"@value\" in \"@option\"",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -119,6 +119,14 @@
     "source": "Favorite blocks",
     "translation": ""
   },
+  "blockOption_bkHiddenGlobally_label": {
+    "source": "Hide globally",
+    "translation": ""
+  },
+  "blockOption_bkVisibleLanguages_label": {
+    "source": "Visible languages",
+    "translation": ""
+  },
   "cancel": {
     "source": "Cancel",
     "translation": "Annuler"
@@ -630,6 +638,10 @@
   "multipleItemsLabel": {
     "source": "Items",
     "translation": "Éléments"
+  },
+  "optionBkVisibleLanguagesAll": {
+    "source": "All languages",
+    "translation": ""
   },
   "optionsCommand.selectCheckboxValue": {
     "source": "Select \"@value\" in \"@option\"",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -355,6 +355,10 @@
     "source": "Show import dialog at start when page is empty",
     "translation": ""
   },
+  "feature_publish_setting_closeAfterPublish_label": {
+    "source": "Close editor after publishing",
+    "translation": ""
+  },
   "feature_settings_setting_lowPerformanceMode_label": {
     "source": "Enable low performance mode",
     "translation": ""
@@ -695,9 +699,21 @@
     "source": "Shows a QR code to quickly open a preview of the changes with your smartphone.",
     "translation": ""
   },
+  "publishAndCloseLabel": {
+    "source": "Publish & Close",
+    "translation": ""
+  },
+  "publishAndCloseLabelUnpublished": {
+    "source": "Save & Close",
+    "translation": ""
+  },
   "publishDescription": {
-    "source": "Make all changes public",
+    "source": "Publish all changes.",
     "translation": "Rendre toutes les modifications publiques"
+  },
+  "publishDescriptionUnpublished": {
+    "source": "Save all changes while keeping page unpublished",
+    "translation": ""
   },
   "publishError": {
     "source": "Changes could not be published.",
@@ -706,6 +722,10 @@
   "publishLabel": {
     "source": "Publish",
     "translation": "Publier"
+  },
+  "publishLabelUnpublished": {
+    "source": "Save",
+    "translation": ""
   },
   "publishSuccess": {
     "source": "Changes published successfully.",

--- a/src/translations/gsw_CH.json
+++ b/src/translations/gsw_CH.json
@@ -355,6 +355,10 @@
     "source": "Show import dialog at start when page is empty",
     "translation": "Importdialog bim Start aazeige wenn d'Sitte leer isch"
   },
+  "feature_publish_setting_closeAfterPublish_label": {
+    "source": "Close editor after publishing",
+    "translation": ""
+  },
   "feature_settings_setting_lowPerformanceMode_label": {
     "source": "Enable low performance mode",
     "translation": ""
@@ -695,9 +699,21 @@
     "source": "Shows a QR code to quickly open a preview of the changes with your smartphone.",
     "translation": ""
   },
+  "publishAndCloseLabel": {
+    "source": "Publish & Close",
+    "translation": ""
+  },
+  "publishAndCloseLabelUnpublished": {
+    "source": "Save & Close",
+    "translation": ""
+  },
   "publishDescription": {
-    "source": "Make all changes public",
+    "source": "Publish all changes.",
     "translation": "Alli änderige öffentlich mache."
+  },
+  "publishDescriptionUnpublished": {
+    "source": "Save all changes while keeping page unpublished",
+    "translation": ""
   },
   "publishError": {
     "source": "Changes could not be published.",
@@ -706,6 +722,10 @@
   "publishLabel": {
     "source": "Publish",
     "translation": "Publiziere"
+  },
+  "publishLabelUnpublished": {
+    "source": "Save",
+    "translation": ""
   },
   "publishSuccess": {
     "source": "Changes published successfully.",

--- a/src/translations/gsw_CH.json
+++ b/src/translations/gsw_CH.json
@@ -119,6 +119,14 @@
     "source": "Favorite blocks",
     "translation": ""
   },
+  "blockOption_bkHiddenGlobally_label": {
+    "source": "Hide globally",
+    "translation": ""
+  },
+  "blockOption_bkVisibleLanguages_label": {
+    "source": "Visible languages",
+    "translation": ""
+  },
   "cancel": {
     "source": "Cancel",
     "translation": "Abbräche"
@@ -630,6 +638,10 @@
   "multipleItemsLabel": {
     "source": "Items",
     "translation": "Elemänt"
+  },
+  "optionBkVisibleLanguagesAll": {
+    "source": "All languages",
+    "translation": ""
   },
   "optionsCommand.selectCheckboxValue": {
     "source": "Select \"@value\" in \"@option\"",

--- a/src/translations/it.json
+++ b/src/translations/it.json
@@ -355,6 +355,10 @@
     "source": "Show import dialog at start when page is empty",
     "translation": ""
   },
+  "feature_publish_setting_closeAfterPublish_label": {
+    "source": "Close editor after publishing",
+    "translation": ""
+  },
   "feature_settings_setting_lowPerformanceMode_label": {
     "source": "Enable low performance mode",
     "translation": ""
@@ -695,9 +699,21 @@
     "source": "Shows a QR code to quickly open a preview of the changes with your smartphone.",
     "translation": ""
   },
+  "publishAndCloseLabel": {
+    "source": "Publish & Close",
+    "translation": ""
+  },
+  "publishAndCloseLabelUnpublished": {
+    "source": "Save & Close",
+    "translation": ""
+  },
   "publishDescription": {
-    "source": "Make all changes public",
+    "source": "Publish all changes.",
     "translation": "Rendi pubbliche tutte le modifiche"
+  },
+  "publishDescriptionUnpublished": {
+    "source": "Save all changes while keeping page unpublished",
+    "translation": ""
   },
   "publishError": {
     "source": "Changes could not be published.",
@@ -706,6 +722,10 @@
   "publishLabel": {
     "source": "Publish",
     "translation": "Pubblica"
+  },
+  "publishLabelUnpublished": {
+    "source": "Save",
+    "translation": ""
   },
   "publishSuccess": {
     "source": "Changes published successfully.",

--- a/src/translations/it.json
+++ b/src/translations/it.json
@@ -119,6 +119,14 @@
     "source": "Favorite blocks",
     "translation": ""
   },
+  "blockOption_bkHiddenGlobally_label": {
+    "source": "Hide globally",
+    "translation": ""
+  },
+  "blockOption_bkVisibleLanguages_label": {
+    "source": "Visible languages",
+    "translation": ""
+  },
   "cancel": {
     "source": "Cancel",
     "translation": "Annulla"
@@ -630,6 +638,10 @@
   "multipleItemsLabel": {
     "source": "Items",
     "translation": "Elementi"
+  },
+  "optionBkVisibleLanguagesAll": {
+    "source": "All languages",
+    "translation": ""
   },
   "optionsCommand.selectCheckboxValue": {
     "source": "Select \"@value\" in \"@option\"",


### PR DESCRIPTION
# Built-in global option: `bkVisibleLanguages`
Can be enabled as a global option on blocks. Once enabled, the option will display all available languages as checkboxes. If one or more languages are selected, the block will only be rendered for the selected languages. During editing the block is always rendered, however it will be displayed translucent to indicate it won't be visible

# Built-in global option: `bkHiddenGlobally`
When enabled and checked the block will always be hidden during non-editor rendering.

# Translatable option labels
Labels for global or per-block options can now also be translated using the special `blockOption_PROPERTY_label` key. For example:

```typescript
const { options } = defineBlokkli({
  bundle: 'card',

  options: {
    showMobile: {
      type: 'checkbox',
      label: 'Show on Mobile',
      default: true,
    },
  },
})
```

This label can now be translated via module configuration:

```typescript
export default defineNuxtConfig({
  blokkli: {
    translations: {
      de: {
        blockOption_showMobile_label: 'Auf Mobile anzeigen',
      },
    },
  },
})
```