### PR TITLE
feat: hide bundles in add list for which no field is rendered (#41)

### DIFF
--- a/src/runtime/components/Edit/DraggableList.vue
+++ b/src/runtime/components/Edit/DraggableList.vue
@@ -200,18 +200,18 @@ function isMuted(item?: FieldListItem) {
 
 watch(root, function (newRoot) {
   if (newRoot) {
-    dom.updateFieldElement(props.entity.uuid, props.name, newRoot)
+    dom.updateFieldElement(props.entity, props.name, newRoot)
   }
 })
 
 onMounted(() => {
   if (root.value) {
-    dom.registerField(props.entity.uuid, props.name, root.value)
+    dom.registerField(props.entity, props.name, root.value)
   }
 })
 
 onBeforeUnmount(() => {
-  dom.unregisterField(props.entity.uuid, props.name)
+  dom.unregisterField(props.entity, props.name)
 })
 
 defineOptions({


### PR DESCRIPTION
- Add some additional context to registered fields
- Use this context to build a list of unique entityType/entityBundle/fieldName combinations
- Using this array the "add list" determines which bundles can actually be added currently

For example: If a `card` can only be added in a `teaser_list`, but there is currently no `teaser_list`, then the `card` will be hidden from the add list.